### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install `adlib`, run `python3 setup.py install`. For development, do `python3
 * NumPy
 * Matplotlib
 * Scikit-learn
-* CVXPY (0.4.11 version)
+* CVXPY (0.4-0.4.11 version)
 * Progress
 * Pathos
 * CVXOPT (optional as a CVXPY solver)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ To install `adlib`, run `python3 setup.py install`. For development, do `python3
 * Matplotlib
 * Scikit-learn
 * CVXPY (0.4-0.4.11 version)
-* Progress
 * Pathos
 * CVXOPT (optional as a CVXPY solver)
 * Jupyter Notebook (optional for notebook demo)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install `adlib`, run `python3 setup.py install`. For development, do `python3
 * NumPy
 * Matplotlib
 * Scikit-learn
-* CVXPY (0.4 version)
+* CVXPY (0.4.11 version)
 * Progress
 * Pathos
 * CVXOPT (optional as a CVXPY solver)

--- a/adlib/__init__.py
+++ b/adlib/__init__.py
@@ -1,6 +1,9 @@
 # Fix CVXPY as some adversaries use cvxpy==0.4.11
+
 import cvxpy
-cvxpy.mul_elemwise = lambda c, x: c * x
+
+if not hasattr(cvxpy, 'mul_elemwise'):
+    cvxpy.mul_elemwise = lambda c, x: c * x
 
 from . import adversaries
 from . import learners

--- a/adlib/__init__.py
+++ b/adlib/__init__.py
@@ -1,3 +1,7 @@
+# Fix CVXPY as some adversaries use cvxpy==0.4.11
+import cvxpy
+cvxpy.mul_elemwise = lambda c, x: c * x
+
 from . import adversaries
 from . import learners
 from . import tests

--- a/adlib/__init__.py
+++ b/adlib/__init__.py
@@ -1,10 +1,3 @@
-# Fix CVXPY as some adversaries use cvxpy==0.4.11
-
-import cvxpy
-
-if not hasattr(cvxpy, 'mul_elemwise'):
-    cvxpy.mul_elemwise = lambda c, x: c * x
-
 from . import adversaries
 from . import learners
 from . import tests

--- a/adlib/adversaries/k_insertion.py
+++ b/adlib/adversaries/k_insertion.py
@@ -100,7 +100,7 @@ class KInsertion(Adversary):
             uv_norm = 0.0
             iteration = 0
             old_update_vector = 0.0
-            max_val = np.max(self.fvs) * 100.0
+            max_val = np.max(self.fvs) * 0.5 * (k + 2) if k < 10 else np.max(self.fvs)
             while (iteration == 0 or (fv_dist > self.alpha and
                                       iteration < self.max_iter)):
 

--- a/adlib/adversaries/k_insertion.py
+++ b/adlib/adversaries/k_insertion.py
@@ -100,7 +100,9 @@ class KInsertion(Adversary):
             uv_norm = 0.0
             iteration = 0
             old_update_vector = 0.0
-            max_val = np.max(self.fvs) * 0.5 * (k + 2) if k < 10 else np.max(self.fvs)
+            max_val = (np.max(self.fvs) * 0.5 * (k + 2)
+                       if k < 10 else np.max(self.fvs))
+
             while (iteration == 0 or (fv_dist > self.alpha and
                                       iteration < self.max_iter)):
 

--- a/adlib/adversaries/label_flipping.py
+++ b/adlib/adversaries/label_flipping.py
@@ -131,7 +131,8 @@ class LabelFlipping(Adversary):
         labels = np.array(labels + labels_flipped)
 
         fvs, _ = get_fvs_and_labels(instances)
-        orig_loss = logistic_loss(fvs, self.learner, labels)
+        orig_loss = logistic_loss(fvs, self.learner,
+                                  np.array(labels[:(len(labels) // 2)]))
         orig_loss = np.concatenate([orig_loss, orig_loss])
 
         cost = np.concatenate([np.full(half_n, 0), np.array(self.cost)])

--- a/adlib/adversaries/label_flipping.py
+++ b/adlib/adversaries/label_flipping.py
@@ -19,7 +19,7 @@ class LabelFlipping(Adversary):
     """
 
     def __init__(self, learner, cost: List[float], total_cost: float,
-                 gamma=0.1, alpha=1e-8, verbose=False):
+                 gamma=0.1, alpha=5e-7, verbose=False):
         """
         :param learner: the previously-trained SVM learner
         :param cost: the cost vector, has length of size of instances

--- a/adlib/adversaries/label_flipping.py
+++ b/adlib/adversaries/label_flipping.py
@@ -71,7 +71,10 @@ class LabelFlipping(Adversary):
         ########################################################################
         # Alternating minimization loop
 
-        q = np.random.rand(n)
+        q = np.random.rand(half_n)
+        q_add_inv = 1 - q
+        q = np.concatenate([q, q_add_inv])
+
         self.q = deepcopy(q)
         q_dist = 0
         iteration = 0

--- a/adlib/learners/__init__.py
+++ b/adlib/learners/__init__.py
@@ -1,4 +1,5 @@
 from .learner import Learner
+from .trim_learner import TRIMLearner
 from .adversary_aware import AdversaryAware
 from .alternating_trim_learner import AlternatingTRIMLearner
 from .feature_deletion import FeatureDeletion
@@ -7,4 +8,3 @@ from .retraining import Retraining
 from .simple_learner import SimpleLearner
 from .svm_freerange import SVMFreeRange
 from .svm_restrained import SVMRestrained
-from .trim_learner import TRIMLearner

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -36,7 +36,7 @@ class IterativeRetrainingLearner(Learner):
         self.learner.train()
         loss = logistic_loss(self.training_instances, self.learner)
 
-        self.loss_threshold = np.mean(loss) + 2.5 * np.std(loss)
+        self.loss_threshold = np.mean(loss) + 2 * np.std(loss)
 
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -50,8 +50,8 @@ class IterativeRetrainingLearner(Learner):
             self.training_instances = instances
 
             if self.verbose:
-                print('Number of instances:', len(self.training_instances))
-                print('Loss threshold:', self.loss_threshold)
+                print('\nNumber of instances:', len(self.training_instances))
+                print('Loss threshold:', self.loss_threshold, '\n')
 
             self.learner.set_training_instances(self.training_instances)
             self.learner.train()

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -36,10 +36,10 @@ class IterativeRetrainingLearner(Learner):
         self.learner.train()
         loss = logistic_loss(self.training_instances, self.learner)
 
+        self.loss_threshold = np.mean(loss) + 3 * np.std(loss)
+
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):
-            self.loss_threshold = np.mean(loss) + 3 * np.std(loss)
-
             old_training_instances = self.training_instances[:]
             instances = []
             for i, inst in enumerate(self.training_instances):

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -36,7 +36,7 @@ class IterativeRetrainingLearner(Learner):
         self.learner.train()
         loss = logistic_loss(self.training_instances, self.learner)
 
-        self.loss_threshold = np.mean(loss) + 3 * np.std(loss)
+        self.loss_threshold = np.mean(loss) + 2.5 * np.std(loss)
 
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -38,8 +38,7 @@ class IterativeRetrainingLearner(Learner):
 
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):
-            q75, q25 = np.percentile(loss, [75, 25])
-            self.loss_threshold = q75 + 2.25 * (q75 - q25)
+            self.loss_threshold = np.mean(loss) + 3 * np.std(loss)
 
             old_training_instances = self.training_instances[:]
             instances = []

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -39,7 +39,7 @@ class IterativeRetrainingLearner(Learner):
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):
             q75, q25 = np.percentile(loss, [75, 25])
-            self.loss_threshold = q75 + 1.5 * (q75 - q25)
+            self.loss_threshold = q75 + 2.25 * (q75 - q25)
 
             old_training_instances = self.training_instances[:]
             instances = []
@@ -51,11 +51,14 @@ class IterativeRetrainingLearner(Learner):
 
             if self.verbose:
                 print('\nNumber of instances:', len(self.training_instances))
-                print('Loss threshold:', self.loss_threshold, '\n')
+                print('Loss threshold:', self.loss_threshold)
 
             self.learner.set_training_instances(self.training_instances)
             self.learner.train()
             loss = logistic_loss(self.training_instances, self.learner)
+
+            if self.verbose:
+                print('Loss:\n', loss, '\n')
 
         self.learner.set_training_instances(self.training_instances)
         self.learner.train()

--- a/adlib/learners/iterative_retraining_learner.py
+++ b/adlib/learners/iterative_retraining_learner.py
@@ -2,8 +2,8 @@
 # A learner that iteratively retrains and removes outliers based on loss.
 # Matthew Sedam
 
-from adlib.learners.learner import Learner
-from adlib.learners.simple_learner import SimpleLearner
+from adlib.learners import Learner
+from adlib.learners import TRIMLearner
 from adlib.utils.common import logistic_loss
 from copy import deepcopy
 from data_reader.binary_input import Instance
@@ -16,7 +16,7 @@ class IterativeRetrainingLearner(Learner):
     A learner that iteratively retrains and removes outliers based on loss.
     """
 
-    def __init__(self, lnr: SimpleLearner, training_instances: List[Instance],
+    def __init__(self, lnr: TRIMLearner, training_instances: List[Instance],
                  verbose=False):
         """
         :param lnr: the base learner
@@ -27,15 +27,14 @@ class IterativeRetrainingLearner(Learner):
         Learner.__init__(self)
         self.learner = deepcopy(lnr)
         self.learner.set_training_instances(training_instances)
-        self.learner.train()
         self.set_training_instances(training_instances)
         self.verbose = verbose
         self.loss_threshold = None
 
     def train(self):
-        loss = logistic_loss(self.training_instances, self.learner)
         self.learner.set_training_instances(self.training_instances)
         self.learner.train()
+        loss = logistic_loss(self.training_instances, self.learner)
 
         old_training_instances = []
         while set(old_training_instances) != set(self.training_instances):
@@ -80,4 +79,4 @@ class IterativeRetrainingLearner(Learner):
         raise NotImplementedError
 
     def decision_function(self, X):
-        return self.learner.model.learner.decision_function(X)
+        return self.decision_function(X)

--- a/adlib/learners/trim_learner.py
+++ b/adlib/learners/trim_learner.py
@@ -67,7 +67,7 @@ class TRIMLearner(Learner):
             # Calculate minimal set
             loss_vector = fvs.dot(w) + b
             loss_vector -= labels
-            loss_vector = list(map(lambda x: x ** 2, loss_vector))
+            loss_vector = loss_vector ** 2
 
             loss_tuples = []
             for i in range(len(loss_vector)):

--- a/adlib/learners/trim_learner.py
+++ b/adlib/learners/trim_learner.py
@@ -109,7 +109,7 @@ class TRIMLearner(Learner):
 
         # Solve problem
         prob = cvx.Problem(cvx.Minimize(loss), [])
-        prob.solve(solver=cvx.SCS, verbose=self.verbose, parallel=True)
+        prob.solve(solver=cvx.ECOS, verbose=self.verbose, parallel=True)
 
         return np.array(w.value).flatten(), b.value
 

--- a/adlib/learners/trim_learner.py
+++ b/adlib/learners/trim_learner.py
@@ -19,7 +19,7 @@ class TRIMLearner(Learner):
     """
 
     def __init__(self, training_instances: List[Instance], n: int, lda=0.1,
-                 verbose=False):
+                 alpha=1e-10, verbose=False):
         """
         :param training_instances: the instances on which to train
         :param n: the number of unpoisoned instances in training_instances - the
@@ -32,6 +32,7 @@ class TRIMLearner(Learner):
         self.training_instances = training_instances
         self.n = n
         self.lda = lda  # lambda
+        self.alpha = alpha
         self.verbose = verbose
         self.num_features = self.training_instances[0].get_feature_count()
         self.w = None
@@ -59,9 +60,9 @@ class TRIMLearner(Learner):
 
         old_loss = -1
         loss = 0
-        while loss != old_loss:
+        while abs(loss - old_loss) < self.alpha:
             if self.verbose:
-                print('Current loss:', loss)
+                print('\nCurrent loss:', loss, '\n')
 
             # Calculate minimal set
             loss_vector = fvs.dot(w) + b

--- a/adlib/learners/trim_learner.py
+++ b/adlib/learners/trim_learner.py
@@ -22,8 +22,8 @@ class TRIMLearner(Learner):
                  alpha=1e-10, verbose=False):
         """
         :param training_instances: the instances on which to train
-        :param n: the number of unpoisoned instances in training_instances - the
-                  size of the original dataset
+        :param n: the number of un-poisoned instances in training_instances
+                  - the size of the original data set
         :param lda: lambda - for regularization term
         :param verbose: if True, the solver will be in verbose mode
         """

--- a/adlib/tests/adversaries/label_flipping_test.py
+++ b/adlib/tests/adversaries/label_flipping_test.py
@@ -14,7 +14,8 @@ import time
 
 
 def test_label_flipping():
-    print('\n#################################################################')
+    print()
+    print('###################################################################')
     print('START label flipping attack.\n')
 
     begin = time.time()
@@ -23,20 +24,12 @@ def test_label_flipping():
     # The path is an index of 400 testing samples(raw email data).
     dataset = EmailDataset(path='./data_reader/data/raw/trec05p-1/test-400',
                            binary=False, raw=True)
-    training_data = load_dataset(dataset)
+
+    training_data, predict_data = dataset.split({'train': 25, 'test': 75})
+    training_data = load_dataset(training_data)
+    predict_data = load_dataset(predict_data)
 
     print('Training sample size: ', len(training_data), '/400\n', sep='')
-
-    # Randomly cut dataset in approximately half
-    rand_choices = np.random.binomial(1, 0.5, len(training_data))
-    new_training_data = []
-    predict_data = []
-    for i in range(len(training_data)):
-        if rand_choices[i] == 1:
-            new_training_data.append(training_data[i])
-        else:
-            predict_data.append(training_data[i])
-    training_data = new_training_data
 
     # Setting the default learner
     # Test simple learner svm
@@ -107,7 +100,8 @@ def test_label_flipping():
     print('\nTotal time: ', round(end - begin, 2), 's', '\n', sep='')
 
     print('\nEND label flipping attack.')
-    print('#################################################################\n')
+    print('###################################################################')
+    print()
 
 
 if __name__ == '__main__':

--- a/adlib/tests/learners/alternating_trim_learner_test.py
+++ b/adlib/tests/learners/alternating_trim_learner_test.py
@@ -57,7 +57,7 @@ def test_alternating_trim_learner():
     # Execute the attack
     if attacker_name == 'label-flipping':
         cost = list(np.random.binomial(2, 0.5, len(training_data)))
-        total_cost = 0.3 * len(training_data)  # flip around ~30% of the labels
+        total_cost = 0.5 * len(training_data)  # flip around ~50% of the labels
         attacker = LabelFlipping(learner, cost, total_cost, verbose=True)
     elif attacker_name == 'k-insertion':
         number_to_add = int(0.25 * len(training_data))
@@ -90,7 +90,7 @@ def test_alternating_trim_learner():
     print('START Alternating TRIM learner.\n')
 
     # Train with TRIM learner
-    alt_trim_learner = AlternatingTRIMLearner(training_data, 0.3, verbose=True)
+    alt_trim_learner = AlternatingTRIMLearner(training_data, 0.5, verbose=True)
     alt_trim_learner.train()
 
     print('\nEND Alternating TRIM learner.')

--- a/adlib/tests/learners/iterative_retraining_learner_test.py
+++ b/adlib/tests/learners/iterative_retraining_learner_test.py
@@ -58,7 +58,7 @@ def test_iterative_retraining_learner():
     # Execute the attack
     if attacker_name == 'label-flipping':
         cost = list(np.random.binomial(2, 0.5, len(training_data)))
-        total_cost = 0.5 * len(training_data)  # flip around ~50% of the labels
+        total_cost = 0.4 * len(training_data)  # flip around ~40% of the labels
         attacker = LabelFlipping(learner, cost, total_cost, verbose=True)
     elif attacker_name == 'k-insertion':
         number_to_add = int(0.25 * len(training_data))
@@ -91,7 +91,7 @@ def test_iterative_retraining_learner():
     print('START Iterative Retraining learner.\n')
 
     iterative_retraining_learner = IterativeRetrainingLearner(
-        TRIMLearner(training_data, int(0.5 * len(training_data)), verbose=True),
+        TRIMLearner(training_data, int(0.4 * len(training_data)), verbose=True),
         attack_data,
         verbose=True)
 

--- a/adlib/tests/learners/iterative_retraining_learner_test.py
+++ b/adlib/tests/learners/iterative_retraining_learner_test.py
@@ -41,7 +41,7 @@ def test_iterative_retraining_learner():
     dataset = EmailDataset(path='./data_reader/data/raw/trec05p-1/test-400',
                            binary=False, raw=True)
 
-    training_data, testing_data = dataset.split({'train': 50, 'test': 50})
+    training_data, testing_data = dataset.split({'train': 25, 'test': 75})
     training_data = load_dataset(training_data)
     testing_data = load_dataset(testing_data)
 
@@ -58,7 +58,7 @@ def test_iterative_retraining_learner():
     # Execute the attack
     if attacker_name == 'label-flipping':
         cost = list(np.random.binomial(2, 0.5, len(training_data)))
-        total_cost = 0.3 * len(training_data)  # flip around ~30% of the labels
+        total_cost = 0.5 * len(training_data)  # flip around ~50% of the labels
         attacker = LabelFlipping(learner, cost, total_cost, verbose=True)
     elif attacker_name == 'k-insertion':
         number_to_add = int(0.25 * len(training_data))
@@ -91,7 +91,7 @@ def test_iterative_retraining_learner():
     print('START Iterative Retraining learner.\n')
 
     iterative_retraining_learner = IterativeRetrainingLearner(
-        TRIMLearner(training_data, int(0.7 * len(training_data)), verbose=True),
+        TRIMLearner(training_data, int(0.5 * len(training_data)), verbose=True),
         attack_data,
         verbose=True)
 

--- a/adlib/tests/learners/iterative_retraining_learner_test.py
+++ b/adlib/tests/learners/iterative_retraining_learner_test.py
@@ -3,12 +3,13 @@
 # Matthew Sedam
 
 
-from adlib.learners import SimpleLearner
-from adlib.learners import IterativeRetrainingLearner
 from adlib.adversaries.label_flipping import LabelFlipping
 from adlib.adversaries.k_insertion import KInsertion
 from adlib.adversaries.datamodification.data_modification import \
     DataModification
+from adlib.learners import IterativeRetrainingLearner
+from adlib.learners import SimpleLearner
+from adlib.learners import TRIMLearner
 from adlib.tests.adversaries.data_modification_test import \
     calculate_target_theta
 from adlib.utils.common import calculate_correct_percentages
@@ -89,9 +90,11 @@ def test_iterative_retraining_learner():
     print('###################################################################')
     print('START Iterative Retraining learner.\n')
 
-    iterative_retraining_learner = IterativeRetrainingLearner(orig_learner,
-                                                              attack_data,
-                                                              verbose=True)
+    iterative_retraining_learner = IterativeRetrainingLearner(
+        TRIMLearner(training_data, int(0.7 * len(training_data)), verbose=True),
+        attack_data,
+        verbose=True)
+
     iterative_retraining_learner.train()
 
     print('\nEND Iterative Retraining learner.')

--- a/adlib/tests/learners/trim_learner_test.py
+++ b/adlib/tests/learners/trim_learner_test.py
@@ -57,7 +57,7 @@ def test_trim_learner():
     # Execute the attack
     if attacker_name == 'label-flipping':
         cost = list(np.random.binomial(2, 0.5, len(training_data)))
-        total_cost = 0.3 * len(training_data)  # flip around ~30% of the labels
+        total_cost = 0.5 * len(training_data)  # flip around ~50% of the labels
         attacker = LabelFlipping(learner, cost, total_cost, verbose=True)
     elif attacker_name == 'k-insertion':
         number_to_add = int(0.25 * len(training_data))
@@ -91,7 +91,7 @@ def test_trim_learner():
 
     # Train with TRIM learner
     trim_learner = TRIMLearner(attack_data,
-                               int(0.7 * len(attack_data)),
+                               int(0.5 * len(attack_data)),
                                verbose=True)
     trim_learner.train()
 

--- a/adlib/utils/common.py
+++ b/adlib/utils/common.py
@@ -115,7 +115,7 @@ def logistic_loss(instances, lnr: Learner, labels=None):
     :return: the loss
     """
 
-    if isinstance(instances, List[Instance]):
+    if isinstance(instances, List):
         fvs, labels = get_fvs_and_labels(instances)
     elif isinstance(instances, np.ndarray):
         fvs = instances

--- a/adlib/utils/common.py
+++ b/adlib/utils/common.py
@@ -45,8 +45,8 @@ def calculate_correct_percentages(orig_labels, attack_labels, instances):
         if attack_labels[i] != instances[i].get_label():
             count += 1
 
-    orig_precent_correct = ((len(instances) - orig_count) * 100 / len(instances))
-    attack_precent_correct = ((len(instances) - count) * 100 / len(instances))
+    orig_precent_correct = (len(instances) - orig_count) * 100 / len(instances)
+    attack_precent_correct = (len(instances) - count) * 100 / len(instances)
     difference = orig_precent_correct - attack_precent_correct
 
     orig_precent_correct = str(round(orig_precent_correct, 4))
@@ -106,15 +106,21 @@ def logistic_function(x):
     return 1 / (1 + math.exp(-1 * x))
 
 
-def logistic_loss(instances: List[Instance], lnr: Learner):
+def logistic_loss(instances, lnr: Learner, labels=None):
     """
     Calculates the logistic loss for instances
-    :param instances: the instances
+    :param instances: the instances, either List[Instance] or np.ndarray
     :param lnr: the learner
+    :param labels: the labels if instances is of type np.ndarray
     :return: the loss
     """
 
-    fvs, labels = get_fvs_and_labels(instances)
+    if isinstance(instances, List[Instance]):
+        fvs, labels = get_fvs_and_labels(instances)
+    elif isinstance(instances, np.ndarray):
+        fvs = instances
+    else:
+        raise ValueError('instances is not a List[Instance] or an np.ndarray.')
 
     loss = lnr.decision_function(fvs)
     loss = -1 * np.multiply(loss, labels)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml
 numpy
 scipy
 sklearn
-cvxpy==0.4.11
+cvxpy>=0.4,<=0.4.11
 matplotlib
 progress
 pathos

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ scipy
 sklearn
 cvxpy>=0.4,<=0.4.11
 matplotlib
-progress
 pathos
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml
 numpy
 scipy
 sklearn
-cvxpy>=0.4
+cvxpy==0.4.11
 matplotlib
 progress
 pathos


### PR DESCRIPTION
- Label-flipping: Use `EmailDataset.split` and output fixes, refactor, use distance < alpha and not number of iterations, use non-integer q value, move to ECOS from SCS for performance reasons (bug seems fixed?), original q has the proper format
- K-Insertion: Bound values in `self.fvs`
- IRL: `SimpleLearner` -> `TRIMLearner`, set `self.loss_threshold` appropriately and only once, move from 50% to 40% of labels flipped during label-flipping attack
- TRIM learner: Switch to ECOS from SCS for speed
- Utils: Add `np.ndarray` support to `logistic_loss`
- CVXPY: Force version 0.4-0.4.11
- General: Use `numpy` functions instead of `map` whenever possible